### PR TITLE
Updated to cc binary

### DIFF
--- a/bin.json
+++ b/bin.json
@@ -1,5 +1,5 @@
 {
-  "linux": "https://s3.us-east-1.amazonaws.com/cloudchainsinc.com/downloads/cc-release-0.5.11-linux.zip",
-  "mac": "https://s3.us-east-1.amazonaws.com/cloudchainsinc.com/downloads/cc-release-0.5.11-osx.zip",
-  "win": "https://s3.us-east-1.amazonaws.com/cloudchainsinc.com/downloads/cc-release-0.5.11-windows.zip"
+  "linux": "https://s3.us-east-1.amazonaws.com/cloudchainsinc.com/downloads/cc-release-0.5.14-linux.zip",
+  "mac": "https://s3.us-east-1.amazonaws.com/cloudchainsinc.com/downloads/cc-release-0.5.14-osx.zip",
+  "win": "https://s3.us-east-1.amazonaws.com/cloudchainsinc.com/downloads/cc-release-0.5.14-windows.zip"
 }

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -310,8 +310,13 @@ autoUpdater.on('error', err => {
 const checkForUpdates = async function() {
   if(!isDev) {
     try {
-      logger.info('Check for updates');
-      await autoUpdater.checkForUpdates();
+      const { version } = fs.readJsonSync(path.resolve(__dirname, '../../package.json'));
+      if(!/-/.test(version)) {
+        logger.info('Check for updates');
+        await autoUpdater.checkForUpdates();
+      } else {
+        logger.info('Test build. Not checking for updates.');
+      }
     } catch(err) {
       logger.error(err.message + '\n' + err.stack);
     }


### PR DESCRIPTION
Do not check for updates on automated test builds

Updated CC version to 0.5.14

Show console and log dust calculation parameters

Check for window before logging to window console

Ignore checking for dev mode in the renderer logger